### PR TITLE
Jacdac Extension

### DIFF
--- a/jacdac/README.md
+++ b/jacdac/README.md
@@ -1,10 +1,1 @@
 # Jacdac + Kitronik :CREATE Simple Servo Control Board for BBC micro:bit
-
-## Use as Extension
-
-This repository can be added as an **extension** in MakeCode.
-
-* open [https://makecode.microbit.org/](https://makecode.microbit.org/)
-* click on **New Project**
-* click on **Extensions** under the gearwheel menu
-* search for "Simple Servo" or enter **https://github.com/kitronikltd/pxt-kitronik-simple-servo/jacdac** and import

--- a/jacdac/README.md
+++ b/jacdac/README.md
@@ -1,0 +1,10 @@
+# Jacdac + Kitronik :CREATE Simple Servo Control Board for BBC micro:bit
+
+## Use as Extension
+
+This repository can be added as an **extension** in MakeCode.
+
+* open [https://makecode.microbit.org/](https://makecode.microbit.org/)
+* click on **New Project**
+* click on **Extensions** under the gearwheel menu
+* search for "Simple Servo" or enter **https://github.com/kitronikltd/pxt-kitronik-simple-servo/jacdac** and import

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -1,6 +1,3 @@
-//% deprecated
-namespace kitronik_simple_servo { }
-
 namespace modules {
     /**
      * Client for the servo1 servo

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -17,49 +17,13 @@ namespace modules {
 }
 
 namespace servers {
-    class ServoServer extends jacdac.Server {
-        dpin: DigitalPin
-        apin: AnalogPin
-        angle: number
-        enabled: boolean
-        offset: number
-
-        constructor(name: string, dpin: DigitalPin, apin: AnalogPin) {
-            super(jacdac.SRV_SERVO, { instanceName: name })
-            this.dpin = dpin
-            this.apin = apin
-            this.angle = 90
-            this.offset = 0
-            this.enabled = false
-            this.sync()
-        }
-
-        handlePacket(pkt: jacdac.JDPacket) {
-            this.enabled = this.handleRegBool(pkt, jacdac.ServoReg.Enabled, this.enabled)
-            this.angle = this.handleRegValue(pkt, jacdac.ServoReg.Angle, jacdac.ServoRegPack.Angle, this.angle)
-            this.offset = this.handleRegValue(pkt, jacdac.ServoReg.Offset, jacdac.ServoRegPack.Offset, this.offset)
-            this.handleRegValue(pkt, jacdac.ServoReg.CurrentAngle, jacdac.ServoRegPack.CurrentAngle, this.angle + this.offset)
-
-            this.sync()
-        }
-
-        sync() {
-            if (!this.enabled)
-                pins.digitalWritePin(this.dpin, 0)
-            else {
-                const degrees = Math.clamp(0, 180, this.angle + this.offset)
-                pins.servoWritePin(this.apin, degrees)
-            }
-        }
-    }
-
     function start() {
         jacdac.productIdentifier = 0x3cc2d4b4
         jacdac.deviceDescription = "Kitronik Simple Servo"
         jacdac.startSelfServers(() => [
-            new ServoServer("servo1", DigitalPin.P8, AnalogPin.P8),
-            new ServoServer("servo2", DigitalPin.P15, AnalogPin.P15),
-            new ServoServer("servo3", DigitalPin.P16, AnalogPin.P16),
+            new jacdac.ServoServer(AnalogPin.P8, { instanceName: "S1" }),
+            new jacdac.ServoServer(AnalogPin.P15, { instanceName: "S2" }),
+            new jacdac.ServoServer(AnalogPin.P16, { instanceName: "S3" }),
         ])
     }
     start()

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -6,17 +6,17 @@ namespace modules {
      * Client for the servo1 servo
      */
     //% fixedInstance whenUsed block="kitronik servo1"
-    export const kitronikServo1 = new ServoClient("kitronik servo1?device=self")
+    export const kitronikServo1 = new ServoClient("kitronik servo1?dev=self&srvo=0")
     /**
      * Client for the servo2 servo
      */
     //% fixedInstance whenUsed block="kitronik servo2"
-    export const kitronikServo2 = new ServoClient("kitronik servo2?device=self")
+    export const kitronikServo2 = new ServoClient("kitronik servo2?dev=self&srvo=1")
     /**
      * Client for the servo3 servo
      */
     //% fixedInstance whenUsed block="kitronik servo3"
-    export const kitronikServo3 = new ServoClient("kitronik servo3?device=self")
+    export const kitronikServo3 = new ServoClient("kitronik servo3?dev=self&srvo=2")
 }
 
 namespace servers {

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -3,17 +3,17 @@ namespace modules {
      * Client for the servo1 servo
      */
     //% fixedInstance whenUsed block="kitronik servo1"
-    export const kitronikServo1 = new ServoClient("kitronik servo1?dev=self&srvo=0")
+    export const kitronikServo1 = new ServoClient("kitronik servo1?dev=self&srvo=0&name=S1")
     /**
      * Client for the servo2 servo
      */
     //% fixedInstance whenUsed block="kitronik servo2"
-    export const kitronikServo2 = new ServoClient("kitronik servo2?dev=self&srvo=1")
+    export const kitronikServo2 = new ServoClient("kitronik servo2?dev=self&srvo=1&name=S2")
     /**
      * Client for the servo3 servo
      */
     //% fixedInstance whenUsed block="kitronik servo3"
-    export const kitronikServo3 = new ServoClient("kitronik servo3?dev=self&srvo=2")
+    export const kitronikServo3 = new ServoClient("kitronik servo3?dev=self&srvo=2&name=S3")
 }
 
 namespace servers {

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -24,11 +24,13 @@ namespace servers {
         readonly servoChoice: kitronik_simple_servo.ServoChoice
         angle: number
         enabled: boolean
+        offset: number
 
         constructor(name: string, servoChoice: kitronik_simple_servo.ServoChoice) {
             super(jacdac.SRV_SERVO, { instanceName: name })
             this.servoChoice = servoChoice
             this.angle = 90
+            this.offset = 0
             this.enabled = false
             kitronik_simple_servo.servoStop(this.servoChoice)
         }
@@ -36,11 +38,13 @@ namespace servers {
         handlePacket(pkt: jacdac.JDPacket) {
             this.enabled = this.handleRegBool(pkt, jacdac.ServoReg.Enabled, this.enabled)
             this.angle = this.handleRegValue(pkt, jacdac.ServoReg.Angle, jacdac.ServoRegPack.Angle, this.angle)
+            this.offset = this.handleRegValue(pkt, jacdac.ServoReg.Offset, jacdac.ServoRegPack.Offset, this.offset)
+            this.handleRegValue(pkt, jacdac.ServoReg.CurrentAngle, jacdac.ServoRegPack.CurrentAngle, this.angle + this.offset)
 
             if (!this.enabled)
                 kitronik_simple_servo.servoStop(this.servoChoice)
             else
-                kitronik_simple_servo.setServoAngle(this.servoChoice, this.angle)
+                kitronik_simple_servo.setServoAngle(this.servoChoice, this.angle + this.offset)
         }
     }
 

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -1,0 +1,56 @@
+//% deprecated
+namespace kitronik_simple_servo { }
+
+namespace modules {
+    /**
+     * Client for the servo1 servo
+     */
+    //% fixedInstance whenUsed block="kitronik servo1"
+    export const kitronikServo1 = new ServoClient("kitronik servo1?device=self")
+    /**
+     * Client for the servo2 servo
+     */
+    //% fixedInstance whenUsed block="kitronik servo2"
+    export const kitronikServo2 = new ServoClient("kitronik servo2?device=self")
+    /**
+     * Client for the servo3 servo
+     */
+    //% fixedInstance whenUsed block="kitronik servo3"
+    export const kitronikServo3 = new ServoClient("kitronik servo3?device=self")
+}
+
+namespace servers {
+    class ServoServer extends jacdac.Server {
+        readonly servoChoice: kitronik_simple_servo.ServoChoice
+        angle: number
+        enabled: boolean
+
+        constructor(name: string, servoChoice: kitronik_simple_servo.ServoChoice) {
+            super(jacdac.SRV_SERVO, { instanceName: name })
+            this.servoChoice = servoChoice
+            this.angle = 90
+            this.enabled = false
+            kitronik_simple_servo.servoStop(this.servoChoice)
+        }
+
+        handlePacket(pkt: jacdac.JDPacket) {
+            this.enabled = this.handleRegBool(pkt, jacdac.ServoReg.Enabled, this.enabled)
+            this.angle = this.handleRegValue(pkt, jacdac.ServoReg.Angle, jacdac.ServoRegPack.Angle, this.angle)
+
+            if (!this.enabled)
+                kitronik_simple_servo.servoStop(this.servoChoice)
+            else
+                kitronik_simple_servo.setServoAngle(this.servoChoice, this.angle)
+        }
+    }
+
+    function start() {
+        jacdac.productIdentifier = 0x3cc2d4b4
+        jacdac.startSelfServers(() => [
+            new ServoServer("servo1", kitronik_simple_servo.ServoChoice.servo1),
+            new ServoServer("servo2", kitronik_simple_servo.ServoChoice.servo2),
+            new ServoServer("servo3", kitronik_simple_servo.ServoChoice.servo3),
+        ])
+    }
+    start()
+}

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -11,7 +11,9 @@
     },
     "files": [
         "main.ts",
-        "README.md",
+        "README.md"
+    ],
+    "testFiles": [
         "test.ts"
     ],
     "targetVersions": {

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,0 +1,24 @@
+{
+    "name": "kitronik-simple-servo-jacdac",
+    "dependencies": {
+        "core": "*",
+        "radio": "*",
+        "microphone": "*",
+        "pxt-kitronik-simple-servo": "github:pelikhan/pxt-kitronik-simple-servo",
+        "jacdac": "github:microsoft/pxt-jacdac#v0.9.5",
+        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.9.5",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.9.5"
+    },
+    "files": [
+        "main.ts",
+        "README.md"
+    ],
+    "targetVersions": {
+        "target": "4.1.20",
+        "targetId": "microbit"
+    },
+    "supportedTargets": [
+        "microbit"
+    ],
+    "preferredEditor": "tsprj"
+}

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -3,10 +3,10 @@
     "version": "0.0.13",
     "dependencies": {
         "core": "*",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.30",
-        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.30",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.30",
-        "jacdac-servo-server": "github:microsoft/pxt-jacdac/servo-server#v0.10.30"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.53",
+        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.53",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.53",
+        "jacdac-servo-server": "github:microsoft/pxt-jacdac/servo-server#v0.10.53"
     },
     "files": [
         "main.ts",
@@ -16,7 +16,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.34",
+        "target": "4.1.45",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-simple-servo-jacdac",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "dependencies": {
         "core": "*",
         "jacdac": "github:microsoft/pxt-jacdac#v0.10.16",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-simple-servo-jacdac",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "dependencies": {
         "core": "*",
         "jacdac": "github:microsoft/pxt-jacdac#v0.10.27",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -11,7 +11,8 @@
     },
     "files": [
         "main.ts",
-        "README.md"
+        "README.md",
+        "test.ts"
     ],
     "targetVersions": {
         "target": "4.1.20",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -3,10 +3,10 @@
     "version": "0.0.11",
     "dependencies": {
         "core": "*",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.16",
-        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.16",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.16",
-        "jacdac-servo-server": "github:microsoft/pxt-jacdac/servo-server#v0.10.16"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.30",
+        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.30",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.30",
+        "jacdac-servo-server": "github:microsoft/pxt-jacdac/servo-server#v0.10.30"
     },
     "files": [
         "main.ts",
@@ -16,7 +16,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.27",
+        "target": "4.1.34",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-simple-servo-jacdac",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "dependencies": {
         "core": "*",
         "jacdac": "github:microsoft/pxt-jacdac#v0.10.15",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -3,9 +3,6 @@
     "version": "0.0.8",
     "dependencies": {
         "core": "*",
-        "radio": "*",
-        "microphone": "*",
-        "pxt-kitronik-simple-servo": "github:pelikhan/pxt-kitronik-simple-servo",
         "jacdac": "github:microsoft/pxt-jacdac#v0.10.14",
         "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.14",
         "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.14"

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-simple-servo-jacdac",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "dependencies": {
         "core": "*",
         "jacdac": "github:microsoft/pxt-jacdac#v0.10.23",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -18,7 +18,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.20",
+        "target": "4.1.21",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,9 +6,9 @@
         "radio": "*",
         "microphone": "*",
         "pxt-kitronik-simple-servo": "github:pelikhan/pxt-kitronik-simple-servo",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.2",
-        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.2",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.2"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.3",
+        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.3",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.3"
     },
     "files": [
         "main.ts",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,5 +1,6 @@
 {
     "name": "kitronik-simple-servo-jacdac",
+    "version": "0.0.5",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-simple-servo-jacdac",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -3,9 +3,10 @@
     "version": "0.0.9",
     "dependencies": {
         "core": "*",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.14",
-        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.14",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.14"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.15",
+        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.15",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.15",
+        "jacdac-servo-server": "github:microsoft/pxt-jacdac/servo-server#v0.10.15"
     },
     "files": [
         "main.ts",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-simple-servo-jacdac",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-simple-servo-jacdac",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-simple-servo-jacdac",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "dependencies": {
         "core": "*",
         "jacdac": "github:microsoft/pxt-jacdac#v0.10.53",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -3,10 +3,10 @@
     "version": "0.0.12",
     "dependencies": {
         "core": "*",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.23",
-        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.23",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.23",
-        "jacdac-servo-server": "github:microsoft/pxt-jacdac/servo-server#v0.10.23"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.27",
+        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.27",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.27",
+        "jacdac-servo-server": "github:microsoft/pxt-jacdac/servo-server#v0.10.27"
     },
     "files": [
         "main.ts",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,9 +6,9 @@
         "radio": "*",
         "microphone": "*",
         "pxt-kitronik-simple-servo": "github:pelikhan/pxt-kitronik-simple-servo",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.3",
-        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.3",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.3"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.14",
+        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.14",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.14"
     },
     "files": [
         "main.ts",
@@ -18,7 +18,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.24",
+        "target": "4.1.27",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,9 +6,9 @@
         "radio": "*",
         "microphone": "*",
         "pxt-kitronik-simple-servo": "github:pelikhan/pxt-kitronik-simple-servo",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.9.5",
-        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.9.5",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.9.5"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.2",
+        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.2",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.2"
     },
     "files": [
         "main.ts",
@@ -18,7 +18,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.21",
+        "target": "4.1.24",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-simple-servo-jacdac",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "dependencies": {
         "core": "*",
         "jacdac": "github:microsoft/pxt-jacdac#v0.10.14",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -3,10 +3,10 @@
     "version": "0.0.10",
     "dependencies": {
         "core": "*",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.15",
-        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.15",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.15",
-        "jacdac-servo-server": "github:microsoft/pxt-jacdac/servo-server#v0.10.15"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.16",
+        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.16",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.16",
+        "jacdac-servo-server": "github:microsoft/pxt-jacdac/servo-server#v0.10.16"
     },
     "files": [
         "main.ts",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -3,10 +3,10 @@
     "version": "0.0.11",
     "dependencies": {
         "core": "*",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.16",
-        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.16",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.16",
-        "jacdac-servo-server": "github:microsoft/pxt-jacdac/servo-server#v0.10.16"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.23",
+        "jacdac-servo": "github:microsoft/pxt-jacdac/servo#v0.10.23",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.23",
+        "jacdac-servo-server": "github:microsoft/pxt-jacdac/servo-server#v0.10.23"
     },
     "files": [
         "main.ts",
@@ -16,7 +16,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.27",
+        "target": "4.1.30",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/test.ts
+++ b/jacdac/test.ts
@@ -13,5 +13,5 @@ forever(function() {
     else if (angle < -90)
         da = 5
     angle += da    
-    pause(100)
+    pause(50)
 })

--- a/jacdac/test.ts
+++ b/jacdac/test.ts
@@ -1,0 +1,17 @@
+let angle = 90
+let da = 5
+forever(function() {
+    modules.kitronikServo1.setEnabled(true)
+    modules.kitronikServo2.setEnabled(true)
+    modules.kitronikServo3.setEnabled(true)
+    modules.kitronikServo1.setAngle(angle)
+    modules.kitronikServo2.setAngle(-angle)
+    modules.kitronikServo3.setAngle(angle / 2)
+
+    if (angle > 90)
+        da = -5
+    else if (angle < -90)
+        da = 5
+    angle += da    
+    pause(100)
+})

--- a/jacdac/test.ts
+++ b/jacdac/test.ts
@@ -1,17 +1,14 @@
 let angle = 90
 let da = 5
 forever(function() {
-    modules.kitronikServo1.setEnabled(true)
-    modules.kitronikServo2.setEnabled(true)
-    modules.kitronikServo3.setEnabled(true)
-    modules.kitronikServo1.setAngle(angle)
-    modules.kitronikServo2.setAngle(-angle)
-    modules.kitronikServo3.setAngle(angle / 2)
+    modules.kitronikServo1.setAngle(angle + 90)
+    modules.kitronikServo2.setAngle(-angle + 90)
+    modules.kitronikServo3.setAngle(angle / 2 + 45)
 
     if (angle > 90)
         da = -5
     else if (angle < -90)
         da = 5
     angle += da    
-    pause(50)
+    pause(100)
 })


### PR DESCRIPTION
This pull requests add support for Jacdac for this accessory which allows users to use simulators in MakeCode. Jacdac support will be released in the next major release of MakeCode for micro:bit (summer 2022).

-   This change adds a new nested extension (`jacdac` folder)
and does not modify the existing extension. **Your existing lessons, tutorials and blocks are not impacted by this change.**
-   No hardware modification is required for existing accessories, this feature
is [backward compatible](https://microsoft.github.io/jacdac-docs/ddk/microbit/software-only-accessory/). However, it requires a micro:bit V2 to run.

The benefits for the users and you will be:

-   **Simulator** Jacdac enables simulations of all sensors and actuators
-   **Digital twins** Jacdac surfaces the hardware state directly into the MakeCode editor
-   **Standardized blocks and lessons** the programming will be done through
Jacdac blocks maintained by the Microsoft team

We recommend reading the [Jacdac software only accessory](https://microsoft.github.io/jacdac-docs/ddk/microbit/software-only-accessory/) documentation page to learn more 
about the details of this approach. You can also review a list of similar [software only extensions](https://microsoft.github.io/jacdac-docs/ddk/microbit/extension-samples/).

Please do not hesitate to contact us through this pull request or at jacdac-tap@microsoft.com 
if you have any question or want to schedule a call.

## How to test this extension as a user?

**This features requires to beta editor of MakeCode at https://makecode.microbit.org/beta.**

- Click on https://microsoft.github.io/jacdac-docs/ddk/microbit/extension-samples/
- Find the extension for this accessory
- Click on **Try MakeCode** to open a project that as a user
- Use the blocks from the **Modules** toolbox

You can follow the [micro:bit Jacdac guide](https://microsoft.github.io/jacdac-docs/clients/makecode/) to learn how Jacdac integrates into MakeCode

## TODOs

- [ ] merge this pull request (**squash recommended**)
- [ ] create a new release for the repository

```
npx makecode bump --patch
```

- [ ] review the accessory page in the [Jacdac device catalog](https://microsoft.github.io/jacdac-docs/devices/) to make sure we got all the details right

Once the pull request is merged, we will update the catalog to point to it rather than our temporary fork.

## Future accessories TODOs

- Review the [micro:bit accessory Jacdac integration guide](https://microsoft.github.io/jacdac-docs/ddk/microbit/) to learn how you can integrate Jacdac into your future accessories for a better user experience. We provide various options to integrate Jacdac into your hardware at minimal cost.
- Review the [Jacdac Device Development Kit](https://microsoft.github.io/jacdac-docs/ddk/) for more details about hardware integration of Jacdac in general.
- Contact us if you have any question about adding Jacdac to your next accessory through [Discussions](https://github.com/microsoft/jacdac/discussions) or at jacdac-tag@microsoft.com.